### PR TITLE
Fix NavLinks

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -29,12 +29,12 @@ function NavigationBar(): FunctionComponentElement<{}> {
               Encounters
             </DropdownToggle>
             <DropdownMenu right>
-              <DropdownItem>
-                <NavLink to="/encounters">List</NavLink>
-              </DropdownItem>
-              <DropdownItem>
-                <NavLink to="/encounters/create">Create</NavLink>
-              </DropdownItem>
+              <NavLink to="/encounters">
+                <DropdownItem>List</DropdownItem>
+              </NavLink>
+              <NavLink to="/encounters/create">
+                <DropdownItem>Create</DropdownItem>
+              </NavLink>
             </DropdownMenu>
           </UncontrolledDropdown>
         </Nav>


### PR DESCRIPTION
### Summary
This allows you to click wherever you want on the item and go to the correct page :)

If accepted, this PR will:

- Fix the nav links so you can click wherever you want on the item (instead of only directly on the word) to get to the page you want

### To Test

1. Run `yarn start`
1. Visit http://localhost:3000/#/
1. Click on the area of the dropdown items in the navbar, but not on the word itself
1. You should still be taken to the correct page!