### PR TITLE
Edit Encounters

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bootstrap": "^4.4.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "moment": "^2.24.0",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "react-router-dom": "^5.1.2",

--- a/src/App.css
+++ b/src/App.css
@@ -20,6 +20,10 @@ html {
   width: 66%;
 }
 
+.error-container {
+  margin: 5%;
+}
+
 .form-field {
   margin-bottom: 10%;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import NavigationBar from './components/NavigationBar'
 import Home from './components/Home'
 import ListEncounters from './components/encounters/ListEncounters'
 import CreateEncounterForm from './components/encounters/CreateEncounterForm'
+import EditEncounterForm from './components/encounters/EditEncounterForm'
 
 function App(): React.FunctionComponentElement<{}> {
   return (
@@ -17,9 +18,10 @@ function App(): React.FunctionComponentElement<{}> {
             <Route exact path="/encounters" component={ListEncounters} />
             <Route
               exact
-              path="/encounters/create"
+              path="/create-encounter"
               component={CreateEncounterForm}
             />
+            <Route exact path="/encounters/:id" component={EditEncounterForm} />
             <Redirect to="/" />
           </Switch>
         </div>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,13 @@ class API {
     this.baseURL = baseURL
   }
 
+  public getEncounter(id: string): Promise<APIResponse<Encounter>> {
+    return this.__request<APIResponse<Encounter>>(
+      'GET',
+      `${this.baseURL}/v1/encounters/${id}`
+    )
+  }
+
   public getEncounters(): Promise<APIResponse<Encounter[]>> {
     return this.__request<APIResponse<Encounter[]>>(
       'GET',

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -30,6 +30,17 @@ class API {
     )
   }
 
+  public updateEncounter(
+    id: string,
+    body: object
+  ): Promise<APIResponse<Encounter>> {
+    return this.__request<APIResponse<Encounter>>(
+      'PUT',
+      `${this.baseURL}/v1/encounters/${id}`,
+      body
+    )
+  }
+
   private async __request<T>(
     method: Method = 'GET',
     endpoint = '',

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -29,12 +29,12 @@ function NavigationBar(): FunctionComponentElement<{}> {
               Encounters
             </DropdownToggle>
             <DropdownMenu right>
-              <DropdownItem>
-                <NavLink to="/encounters">List</NavLink>
-              </DropdownItem>
-              <DropdownItem>
-                <NavLink to="/encounters/create">Create</NavLink>
-              </DropdownItem>
+              <NavLink to="/encounters">
+                <DropdownItem>List</DropdownItem>
+              </NavLink>
+              <NavLink to="/create-encounter">
+                <DropdownItem>Create</DropdownItem>
+              </NavLink>
             </DropdownMenu>
           </UncontrolledDropdown>
         </Nav>

--- a/src/components/encounters/EditEncounterForm.tsx
+++ b/src/components/encounters/EditEncounterForm.tsx
@@ -69,6 +69,7 @@ function EditEncounterForm(
         title: `Encounter "${result.title}" successfully updated!`,
         icon: 'success'
       })
+      setEncounter(result)
     } catch (error) {
       console.error(error)
       Swal.fire({

--- a/src/components/encounters/EditEncounterForm.tsx
+++ b/src/components/encounters/EditEncounterForm.tsx
@@ -2,6 +2,20 @@ import React, { FunctionComponentElement, useState, useEffect } from 'react'
 import { RouterProps } from '../../types/reactRouterProps'
 import { Encounter } from '../../types/encounter.type'
 import api from '../../api'
+import {
+  Alert,
+  Spinner,
+  Card,
+  CardHeader,
+  CardTitle,
+  CardBody,
+  Form,
+  Col,
+  FormGroup,
+  Input,
+  FormText,
+  Button
+} from 'reactstrap'
 
 function EditEncounterForm(
   props: RouterProps
@@ -23,9 +37,66 @@ function EditEncounterForm(
     fetchEncounter()
   }, [id])
 
-  console.error(error)
-  console.log(encounter?.title)
-  return <p>{encounter?.title}</p>
+  if (error) {
+    return (
+      <Alert className="error-container" color="danger">
+        {error.message}
+      </Alert>
+    )
+  }
+
+  if (!encounter) {
+    return <Spinner color="primary" />
+  }
+
+  const isDisabled = (): boolean => !encounter.title || !encounter.description
+
+  return (
+    <Card className="form-container text-center">
+      <CardHeader>
+        <CardTitle tag="h2">Edit Encounter</CardTitle>
+      </CardHeader>
+
+      <CardBody>
+        <Form>
+          <Col>
+            <FormGroup className="form-field">
+              <Input
+                id="create-encounter-title-input"
+                type="text"
+                placeholder="Title"
+                value={encounter.title}
+                onChange={(e): string =>
+                  (encounter.title = e.currentTarget.value)
+                }
+              />
+              <FormText color="muted" className="float-left">
+                Please make sure the title is unique!
+              </FormText>
+            </FormGroup>
+          </Col>
+
+          <Col>
+            <FormGroup className="form-field">
+              <Input
+                id="create-encounter-description-input"
+                type="textarea"
+                placeholder="Description"
+                value={encounter.description}
+                onChange={(e): string =>
+                  (encounter.description = e.currentTarget.value)
+                }
+              />
+            </FormGroup>
+          </Col>
+
+          <Button color="primary" disabled={isDisabled()}>
+            Update Encounter
+          </Button>
+        </Form>
+      </CardBody>
+    </Card>
+  )
 }
 
 export default EditEncounterForm

--- a/src/components/encounters/EditEncounterForm.tsx
+++ b/src/components/encounters/EditEncounterForm.tsx
@@ -1,0 +1,31 @@
+import React, { FunctionComponentElement, useState, useEffect } from 'react'
+import { RouterProps } from '../../types/reactRouterProps'
+import { Encounter } from '../../types/encounter.type'
+import api from '../../api'
+
+function EditEncounterForm(
+  props: RouterProps
+): FunctionComponentElement<RouterProps> {
+  const { id } = props.match.params
+  const [encounter, setEncounter] = useState<Encounter>()
+  const [error, setError] = useState<Error>()
+
+  useEffect(() => {
+    async function fetchEncounter(): Promise<void> {
+      try {
+        const { result } = await api.getEncounter(id)
+        setEncounter(result)
+      } catch (err) {
+        setError(err)
+      }
+    }
+
+    fetchEncounter()
+  }, [id])
+
+  console.error(error)
+  console.log(encounter?.title)
+  return <p>{encounter?.title}</p>
+}
+
+export default EditEncounterForm

--- a/src/components/encounters/EditEncounterForm.tsx
+++ b/src/components/encounters/EditEncounterForm.tsx
@@ -17,6 +17,7 @@ import {
   CardTitle,
   CardBody,
   Form,
+  Row,
   Col,
   FormGroup,
   Label,
@@ -136,31 +137,33 @@ function EditEncounterForm(
             </FormGroup>
           </Col>
 
-          <Col>
-            <FormGroup className="form-field">
-              <Label for="edit-encounter-created-at-date">Created At</Label>
-              <Input
-                id="edit-encounter-created-at-date"
-                type="date"
-                value={moment(encounter.createdAt).format(format)}
-                disabled
-              />
-            </FormGroup>
-          </Col>
+          <Row>
+            <Col>
+              <FormGroup className="form-field">
+                <Label for="edit-encounter-created-at-date">Created At</Label>
+                <Input
+                  id="edit-encounter-created-at-date"
+                  type="date"
+                  value={moment(encounter.createdAt).format(format)}
+                  disabled
+                />
+              </FormGroup>
+            </Col>
 
-          <Col>
-            <FormGroup className="form-field">
-              <Label for="edit-encounter-updated-at-date">
-                Last Updated At
-              </Label>
-              <Input
-                id="edit-encounter-updated-at-date"
-                type="date"
-                value={moment(encounter.updatedAt).format(format)}
-                disabled
-              />
-            </FormGroup>
-          </Col>
+            <Col>
+              <FormGroup className="form-field">
+                <Label for="edit-encounter-updated-at-date">
+                  Last Updated At
+                </Label>
+                <Input
+                  id="edit-encounter-updated-at-date"
+                  type="date"
+                  value={moment(encounter.updatedAt).format(format)}
+                  disabled
+                />
+              </FormGroup>
+            </Col>
+          </Row>
 
           <div className="text-center">
             <Button color="primary" onClick={onClick} disabled={isDisabled()}>

--- a/src/components/encounters/EditEncounterForm.tsx
+++ b/src/components/encounters/EditEncounterForm.tsx
@@ -1,5 +1,6 @@
 import React, {
   FunctionComponentElement,
+  ReactElement,
   useState,
   useEffect,
   FormEvent
@@ -48,20 +49,12 @@ function EditEncounterForm(
     fetchEncounter()
   }, [id])
 
-  if (error) {
-    return (
-      <Alert className="error-container" color="danger">
-        {error.message}
-      </Alert>
-    )
-  }
-
-  if (!encounter) {
-    return <Spinner color="primary" />
-  }
-
   const onClick = async (event: FormEvent<HTMLInputElement>): Promise<void> => {
     event.preventDefault()
+
+    if (!encounter) {
+      return
+    }
 
     try {
       const { result } = await api.updateEncounter(id, encounter)
@@ -70,6 +63,7 @@ function EditEncounterForm(
         title: `Encounter "${result.title}" successfully updated!`,
         icon: 'success'
       })
+
       setEncounter(result)
     } catch (error) {
       console.error(error)
@@ -81,7 +75,109 @@ function EditEncounterForm(
     }
   }
 
-  const isDisabled = (): boolean => !encounter.title || !encounter.description
+  const isDisabled = (): boolean => !encounter?.title || !encounter?.description
+
+  const getCardBody = (): ReactElement => {
+    if (error) {
+      return (
+        <Alert className="error-container text-center" color="danger">
+          {error.message}
+        </Alert>
+      )
+    }
+
+    if (!encounter) {
+      return (
+        <div className="text-center">
+          <Spinner color="dark" />
+        </div>
+      )
+    }
+
+    return (
+      <Form>
+        <Col>
+          <FormGroup className="form-field">
+            <Label for="edit-encounter-title-input">Title</Label>
+            <Input
+              id="edit-encounter-title-input"
+              type="text"
+              value={encounter.title}
+              onChange={(e): void =>
+                setEncounter({ ...encounter, title: e.currentTarget.value })
+              }
+            />
+            <FormText color="muted" className="float-left">
+              Please make sure the title is unique!
+            </FormText>
+          </FormGroup>
+        </Col>
+
+        <Col>
+          <FormGroup className="form-field">
+            <Label for="edit-encounter-description-input">Description</Label>
+            <Input
+              id="edit-encounter-description-input"
+              type="textarea"
+              value={encounter.description}
+              onChange={(e): void =>
+                setEncounter({
+                  ...encounter,
+                  description: e.currentTarget.value
+                })
+              }
+            />
+          </FormGroup>
+        </Col>
+
+        <Col>
+          <FormGroup className="form-field">
+            <Label for="edit-encounter-times-used">Times Used</Label>
+            <Input
+              id="edit-encounter-times-used"
+              type="number"
+              value={encounter.numberOfRuns}
+              disabled
+            />
+          </FormGroup>
+        </Col>
+
+        <Row>
+          <Col>
+            <FormGroup className="form-field">
+              <Label for="edit-encounter-created-at-date">Created At</Label>
+              <Input
+                id="edit-encounter-created-at-date"
+                type="date"
+                value={moment(encounter.createdAt).format(format)}
+                disabled
+              />
+            </FormGroup>
+          </Col>
+
+          <Col>
+            <FormGroup className="form-field">
+              <Label for="edit-encounter-updated-at-date">
+                Last Updated At
+              </Label>
+              <Input
+                id="edit-encounter-updated-at-date"
+                type="date"
+                value={moment(encounter.updatedAt).format(format)}
+                disabled
+              />
+            </FormGroup>
+          </Col>
+        </Row>
+
+        <div className="text-center">
+          <Button color="primary" onClick={onClick} disabled={isDisabled()}>
+            Update Encounter
+          </Button>
+        </div>
+      </Form>
+    )
+  }
 
   return (
     <Card className="form-container">
@@ -89,89 +185,7 @@ function EditEncounterForm(
         <CardTitle tag="h2">Edit Encounter</CardTitle>
       </CardHeader>
 
-      <CardBody>
-        <Form>
-          <Col>
-            <FormGroup className="form-field">
-              <Label for="edit-encounter-title-input">Title</Label>
-              <Input
-                id="edit-encounter-title-input"
-                type="text"
-                value={encounter.title}
-                onChange={(e): void =>
-                  setEncounter({ ...encounter, title: e.currentTarget.value })
-                }
-              />
-              <FormText color="muted" className="float-left">
-                Please make sure the title is unique!
-              </FormText>
-            </FormGroup>
-          </Col>
-
-          <Col>
-            <FormGroup className="form-field">
-              <Label for="edit-encounter-description-input">Description</Label>
-              <Input
-                id="edit-encounter-description-input"
-                type="textarea"
-                value={encounter.description}
-                onChange={(e): void =>
-                  setEncounter({
-                    ...encounter,
-                    description: e.currentTarget.value
-                  })
-                }
-              />
-            </FormGroup>
-          </Col>
-
-          <Col>
-            <FormGroup className="form-field">
-              <Label for="edit-encounter-times-used">Times Used</Label>
-              <Input
-                id="edit-encounter-times-used"
-                type="number"
-                value={encounter.numberOfRuns}
-                disabled
-              />
-            </FormGroup>
-          </Col>
-
-          <Row>
-            <Col>
-              <FormGroup className="form-field">
-                <Label for="edit-encounter-created-at-date">Created At</Label>
-                <Input
-                  id="edit-encounter-created-at-date"
-                  type="date"
-                  value={moment(encounter.createdAt).format(format)}
-                  disabled
-                />
-              </FormGroup>
-            </Col>
-
-            <Col>
-              <FormGroup className="form-field">
-                <Label for="edit-encounter-updated-at-date">
-                  Last Updated At
-                </Label>
-                <Input
-                  id="edit-encounter-updated-at-date"
-                  type="date"
-                  value={moment(encounter.updatedAt).format(format)}
-                  disabled
-                />
-              </FormGroup>
-            </Col>
-          </Row>
-
-          <div className="text-center">
-            <Button color="primary" onClick={onClick} disabled={isDisabled()}>
-              Update Encounter
-            </Button>
-          </div>
-        </Form>
-      </CardBody>
+      <CardBody>{getCardBody()}</CardBody>
     </Card>
   )
 }

--- a/src/components/encounters/EditEncounterForm.tsx
+++ b/src/components/encounters/EditEncounterForm.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponentElement, useState, useEffect } from 'react'
 import { RouterProps } from '../../types/reactRouterProps'
 import { Encounter } from '../../types/encounter.type'
+import moment from 'moment'
 import api from '../../api'
 import {
   Alert,
@@ -12,10 +13,13 @@ import {
   Form,
   Col,
   FormGroup,
+  Label,
   Input,
   FormText,
   Button
 } from 'reactstrap'
+
+const format = 'YYYY-MM-DD'
 
 function EditEncounterForm(
   props: RouterProps
@@ -52,8 +56,8 @@ function EditEncounterForm(
   const isDisabled = (): boolean => !encounter.title || !encounter.description
 
   return (
-    <Card className="form-container text-center">
-      <CardHeader>
+    <Card className="form-container">
+      <CardHeader className="text-center">
         <CardTitle tag="h2">Edit Encounter</CardTitle>
       </CardHeader>
 
@@ -61,10 +65,10 @@ function EditEncounterForm(
         <Form>
           <Col>
             <FormGroup className="form-field">
+              <Label for="edit-encounter-title-input">Title</Label>
               <Input
-                id="create-encounter-title-input"
+                id="edit-encounter-title-input"
                 type="text"
-                placeholder="Title"
                 value={encounter.title}
                 onChange={(e): string =>
                   (encounter.title = e.currentTarget.value)
@@ -78,10 +82,10 @@ function EditEncounterForm(
 
           <Col>
             <FormGroup className="form-field">
+              <Label for="edit-encounter-description-input">Description</Label>
               <Input
-                id="create-encounter-description-input"
+                id="edit-encounter-description-input"
                 type="textarea"
-                placeholder="Description"
                 value={encounter.description}
                 onChange={(e): string =>
                   (encounter.description = e.currentTarget.value)
@@ -90,9 +94,49 @@ function EditEncounterForm(
             </FormGroup>
           </Col>
 
-          <Button color="primary" disabled={isDisabled()}>
-            Update Encounter
-          </Button>
+          <Col>
+            <FormGroup className="form-field">
+              <Label for="edit-encounter-times-used">Times Used</Label>
+              <Input
+                id="edit-encounter-times-used"
+                type="number"
+                value={encounter.numberOfRuns}
+                disabled
+              />
+            </FormGroup>
+          </Col>
+
+          <Col>
+            <FormGroup className="form-field">
+              <Label for="edit-encounter-created-at-date">Created At</Label>
+              <Input
+                id="edit-encounter-created-at-date"
+                type="date"
+                value={moment(encounter.createdAt).format(format)}
+                disabled
+              />
+            </FormGroup>
+          </Col>
+
+          <Col>
+            <FormGroup className="form-field">
+              <Label for="edit-encounter-updated-at-date">
+                Last Updated At
+              </Label>
+              <Input
+                id="edit-encounter-updated-at-date"
+                type="date"
+                value={moment(encounter.updatedAt).format(format)}
+                disabled
+              />
+            </FormGroup>
+          </Col>
+
+          <div className="text-center">
+            <Button color="primary" disabled={isDisabled()}>
+              Update Encounter
+            </Button>
+          </div>
         </Form>
       </CardBody>
     </Card>

--- a/src/components/encounters/EditEncounterForm.tsx
+++ b/src/components/encounters/EditEncounterForm.tsx
@@ -1,7 +1,13 @@
-import React, { FunctionComponentElement, useState, useEffect } from 'react'
+import React, {
+  FunctionComponentElement,
+  useState,
+  useEffect,
+  FormEvent
+} from 'react'
 import { RouterProps } from '../../types/reactRouterProps'
 import { Encounter } from '../../types/encounter.type'
 import moment from 'moment'
+import Swal from 'sweetalert2'
 import api from '../../api'
 import {
   Alert,
@@ -53,6 +59,26 @@ function EditEncounterForm(
     return <Spinner color="primary" />
   }
 
+  const onClick = async (event: FormEvent<HTMLInputElement>): Promise<void> => {
+    event.preventDefault()
+
+    try {
+      const { result } = await api.updateEncounter(id, encounter)
+
+      Swal.fire({
+        title: `Encounter "${result.title}" successfully updated!`,
+        icon: 'success'
+      })
+    } catch (error) {
+      console.error(error)
+      Swal.fire({
+        title: "Sorry, we couldn't update your encounter!",
+        text: error.message,
+        icon: 'error'
+      })
+    }
+  }
+
   const isDisabled = (): boolean => !encounter.title || !encounter.description
 
   return (
@@ -70,8 +96,8 @@ function EditEncounterForm(
                 id="edit-encounter-title-input"
                 type="text"
                 value={encounter.title}
-                onChange={(e): string =>
-                  (encounter.title = e.currentTarget.value)
+                onChange={(e): void =>
+                  setEncounter({ ...encounter, title: e.currentTarget.value })
                 }
               />
               <FormText color="muted" className="float-left">
@@ -87,8 +113,11 @@ function EditEncounterForm(
                 id="edit-encounter-description-input"
                 type="textarea"
                 value={encounter.description}
-                onChange={(e): string =>
-                  (encounter.description = e.currentTarget.value)
+                onChange={(e): void =>
+                  setEncounter({
+                    ...encounter,
+                    description: e.currentTarget.value
+                  })
                 }
               />
             </FormGroup>
@@ -133,7 +162,7 @@ function EditEncounterForm(
           </Col>
 
           <div className="text-center">
-            <Button color="primary" disabled={isDisabled()}>
+            <Button color="primary" onClick={onClick} disabled={isDisabled()}>
               Update Encounter
             </Button>
           </div>

--- a/src/components/encounters/ListEncounters.tsx
+++ b/src/components/encounters/ListEncounters.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponentElement, useState, useEffect } from 'react'
+import React, {
+  FunctionComponentElement,
+  useState,
+  useEffect,
+  ReactElement
+} from 'react'
 import { Encounter } from '../../types/encounter.type'
 import { Link } from 'react-router-dom'
 import api from '../../api'
@@ -32,16 +37,35 @@ function ListEncounters(): FunctionComponentElement<{}> {
     fetchEncounters()
   }, [])
 
-  if (error) {
-    return (
-      <Alert className="error-container" color="danger">
-        {error.message}
-      </Alert>
-    )
-  }
+  const getCardBody = (): ReactElement => {
+    if (error) {
+      return (
+        <Alert className="error-container text-center" color="danger">
+          {error.message}
+        </Alert>
+      )
+    }
 
-  if (!encounters) {
-    return <Spinner color="primary" />
+    if (!encounters.length) {
+      return (
+        <div className="text-center">
+          <Spinner color="dark" />
+        </div>
+      )
+    }
+
+    return (
+      <ListGroup>
+        {encounters.map((encounter, i) => (
+          <ListGroupItem key={`encounter-${i}`}>
+            <ListGroupItemHeading>
+              <Link to={`/encounters/${encounter._id}`}>{encounter.title}</Link>
+            </ListGroupItemHeading>
+            <ListGroupItemText>{encounter.description}</ListGroupItemText>
+          </ListGroupItem>
+        ))}
+      </ListGroup>
+    )
   }
 
   return (
@@ -52,20 +76,7 @@ function ListEncounters(): FunctionComponentElement<{}> {
         </CardTitle>
       </CardHeader>
 
-      <CardBody>
-        <ListGroup>
-          {encounters.map((encounter, i) => (
-            <ListGroupItem key={`encounter-${i}`}>
-              <ListGroupItemHeading>
-                <Link to={`/encounters/${encounter._id}`}>
-                  {encounter.title}
-                </Link>
-              </ListGroupItemHeading>
-              <ListGroupItemText>{encounter.description}</ListGroupItemText>
-            </ListGroupItem>
-          ))}
-        </ListGroup>
-      </CardBody>
+      <CardBody>{getCardBody()}</CardBody>
     </Card>
   )
 }

--- a/src/components/encounters/ListEncounters.tsx
+++ b/src/components/encounters/ListEncounters.tsx
@@ -32,7 +32,11 @@ function ListEncounters(): FunctionComponentElement<{}> {
   }, [])
 
   if (error) {
-    return <Alert color="danger">{error}</Alert>
+    return (
+      <Alert className="error-container" color="danger">
+        {error.message}
+      </Alert>
+    )
   }
 
   if (!encounters) {

--- a/src/components/encounters/ListEncounters.tsx
+++ b/src/components/encounters/ListEncounters.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponentElement, useState, useEffect } from 'react'
 import { Encounter } from '../../types/encounter.type'
+import { Link } from 'react-router-dom'
 import api from '../../api'
 import {
   Alert,
@@ -55,7 +56,11 @@ function ListEncounters(): FunctionComponentElement<{}> {
         <ListGroup>
           {encounters.map((encounter, i) => (
             <ListGroupItem key={`encounter-${i}`}>
-              <ListGroupItemHeading>{encounter.title}</ListGroupItemHeading>
+              <ListGroupItemHeading>
+                <Link to={`/encounters/${encounter._id}`}>
+                  {encounter.title}
+                </Link>
+              </ListGroupItemHeading>
               <ListGroupItemText>{encounter.description}</ListGroupItemText>
             </ListGroupItem>
           ))}

--- a/src/types/encounter.type.ts
+++ b/src/types/encounter.type.ts
@@ -8,9 +8,9 @@ export interface Encounter {
   /** How many times this encounter has been run. Defaults to 0 */
   numberOfRuns: number
   /** The date this document was created. Created by Mongoose */
-  createdAt: Date
+  createdAt: string
   /** The last date this document was updated. Created by Mongoose */
-  updatedAt: Date
+  updatedAt: string
   /** The version number for this document. Created by Mongoose */
   __v: number
   /** This encounter's Mongo ObjectID */

--- a/src/types/reactRouterProps.ts
+++ b/src/types/reactRouterProps.ts
@@ -1,0 +1,3 @@
+export interface RouterProps {
+  match: { params: { [x: string]: string } }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6966,6 +6966,11 @@ mkdirp@0.5.1, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 moo@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"


### PR DESCRIPTION
### Summary
This PR allows users to edit existing encounters by click on the titles in the list.

If accepted, this PR will:

- Create a new form for displaying/editing encounters
- Create links from the encounters in the List Encounters component to the Edit Encounter Form
- Change some styling
- Move Loading Spinners and Error Alerts into the card bodies so that they display inside the card rather than replacing them entirely

### To Test

1. Run `yarn && yarn start`
1. Create an encounter at http://localhost:3000/create-encounter
1. Go to http://localhost:3000/encounters
1. Click on the title of the encounter you just created
1. You should see the new form!
1. Try changing some of the fields and clicking the "Update Encounter" button