### PR TITLE
Edit Encounter Tweaks

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -41,6 +41,13 @@ class API {
     )
   }
 
+  public deleteEncounter(id: string): Promise<APIResponse<Encounter>> {
+    return this.__request<APIResponse<Encounter>>(
+      'DELETE',
+      `${this.baseURL}/v1/encounters/${id}`
+    )
+  }
+
   private async __request<T>(
     method: Method = 'GET',
     endpoint = '',

--- a/src/components/encounters/EditEncounterForm.test.tsx
+++ b/src/components/encounters/EditEncounterForm.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import EditEncounterForm from './EditEncounterForm'
+
+const mockProps = (): { params: { [key: string]: string } } => {
+  return { params: { id: 'test-id' } }
+}
+
+// TODO Figure out how to do more tests
+describe('EditEncounterForm', () => {
+  test('renders', () => {
+    shallow(<EditEncounterForm match={mockProps()} />)
+  })
+})

--- a/src/components/encounters/EditEncounterForm.tsx
+++ b/src/components/encounters/EditEncounterForm.tsx
@@ -18,6 +18,7 @@ import {
   CardHeader,
   CardTitle,
   CardBody,
+  CardFooter,
   Form,
   Row,
   Col,
@@ -187,34 +188,6 @@ function EditEncounterForm(
           </FormGroup>
         </Col>
 
-        <Row>
-          <Col>
-            <FormGroup className="form-field">
-              <Label for="edit-encounter-created-at-date">Created At</Label>
-              <Input
-                id="edit-encounter-created-at-date"
-                type="date"
-                value={moment(encounter.createdAt).format(format)}
-                disabled
-              />
-            </FormGroup>
-          </Col>
-
-          <Col>
-            <FormGroup className="form-field">
-              <Label for="edit-encounter-updated-at-date">
-                Last Updated At
-              </Label>
-              <Input
-                id="edit-encounter-updated-at-date"
-                type="date"
-                value={moment(encounter.updatedAt).format(format)}
-                disabled
-              />
-            </FormGroup>
-          </Col>
-        </Row>
-
         <Row className="text-center">
           <Col>
             <Button
@@ -242,6 +215,13 @@ function EditEncounterForm(
       </CardHeader>
 
       <CardBody>{getCardBody()}</CardBody>
+
+      <CardFooter>
+        <Row className="text-center">
+          <Col>Created: {moment(encounter?.createdAt).fromNow()}</Col>
+          <Col>Last Edited: {moment(encounter?.updatedAt).fromNow()}</Col>
+        </Row>
+      </CardFooter>
     </Card>
   )
 }


### PR DESCRIPTION
### Summary
This PR displays the Created and Last Updated dates in a more meaningful way, and adds a test around the EditEncounterForm

If accepted, this PR will:

- Display the Created and Last Updated dates as "time from now" as opposed to the hard dates
- Display the Created and Last Updated dates in the footer of the card rather than as part of the form
- Wrap a very basic test around the EditEncounterForm

### To Test

1. Visit the http://localhost:3000/encounters/<MongID>
1. If there's an encounter that exists in your database with that MongoID, then you'll see the Created and Last Updated in the footer of the card!

### Suggested Reading

- [MomentJS Relevant Documentation](https://momentjs.com/docs/#/displaying/fromnow/)
