### PR TITLE
Change HTML title to Zombie RPG 3000

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Zombie RPG 3000</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
### Summary
It was bothering me that it still said "React App" for the title in the browser tab, so I wanted to correct that real quick. :)

If accepted, this PR will:

- Change the title in the tab to "Zombie RPG 3000"

### To Test

1. `yarn start`
1. Look at the tab in the browser - it should say "Zombie RPG 3000" instead of "React App"