### PR TITLE
Create Encounter Button

### DIFF
--- a/src/components/encounters/ListEncounters.tsx
+++ b/src/components/encounters/ListEncounters.tsx
@@ -5,19 +5,23 @@ import React, {
   ReactElement
 } from 'react'
 import { Encounter } from '../../types/encounter.type'
-import { Link } from 'react-router-dom'
+import { Link, NavLink } from 'react-router-dom'
 import api from '../../api'
 import {
   Alert,
-  Spinner,
+  Button,
   Card,
+  CardBody,
   CardHeader,
   CardTitle,
-  CardBody,
+  Col,
+  Container,
   ListGroup,
   ListGroupItem,
   ListGroupItemHeading,
-  ListGroupItemText
+  ListGroupItemText,
+  Row,
+  Spinner
 } from 'reactstrap'
 
 function ListEncounters(): FunctionComponentElement<{}> {
@@ -71,9 +75,23 @@ function ListEncounters(): FunctionComponentElement<{}> {
   return (
     <Card className="app-container">
       <CardHeader>
-        <CardTitle tag="h2" className="text-center">
-          Encounters
-        </CardTitle>
+        <Container>
+          <Row>
+            <Col></Col>
+            <Col></Col>
+            <Col>
+              <CardTitle tag="h2" className="text-center">
+                Encounters
+              </CardTitle>
+            </Col>
+            <Col></Col>
+            <Col>
+              <NavLink to="/create-encounter">
+                <Button color="success">+ New Encounter</Button>
+              </NavLink>
+            </Col>
+          </Row>
+        </Container>
       </CardHeader>
 
       <CardBody>{getCardBody()}</CardBody>


### PR DESCRIPTION
### Summary
It bothered me how I had to go into the NavBar when looking at encounters to create a new one, so I thought a button at the top of the list would help ease that pain.

If accepted, this PR will:

- Add a Create Encounter button to the header of the Encounter list

### To Test

1. Run `yarn && yarn start`
1. Go to http://localhost:3000/#/encounters/
1. You should see a green Create Encounter button at the top of the list