### PR TITLE
Fix Infinite Loading Spinner When No Encounters Exist

### DIFF
--- a/src/components/encounters/ListEncounters.tsx
+++ b/src/components/encounters/ListEncounters.tsx
@@ -27,14 +27,19 @@ import {
 function ListEncounters(): FunctionComponentElement<{}> {
   const [encounters, setEncounters] = useState<Encounter[]>([])
   const [error, setError] = useState<Error>()
+  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    setLoading(true)
+
     async function fetchEncounters(): Promise<void> {
       try {
         const { result } = await api.getEncounters()
         setEncounters(result)
       } catch (err) {
         setError(err)
+      } finally {
+        setLoading(false)
       }
     }
 
@@ -50,7 +55,7 @@ function ListEncounters(): FunctionComponentElement<{}> {
       )
     }
 
-    if (!encounters.length) {
+    if (loading) {
       return (
         <div className="text-center">
           <Spinner color="dark" />

--- a/src/components/encounters/ListEncounters.tsx
+++ b/src/components/encounters/ListEncounters.tsx
@@ -63,6 +63,15 @@ function ListEncounters(): FunctionComponentElement<{}> {
       )
     }
 
+    if (!encounters.length) {
+      return (
+        <Alert color="info" className="text-center">
+          It looks like no encounters have been created yet! Click the New
+          Encounter button above to get started.
+        </Alert>
+      )
+    }
+
     return (
       <ListGroup>
         {encounters.map((encounter, i) => (


### PR DESCRIPTION
### Summary
This PR is being made to fix a bug where a loading spinner would spin infinitely when there were no encounters in the database to display to the user.

If accepted, this PR will:

- No longer show the loading spinner based on the length of the array returned from the server
- Display a nice alert explaining that there are no encounters to display when the server returns no encounters

### To Test

1. Delete all encounters
1. Navigate to http://localhost:3000/#/encounters/
1. The loading spinner should only last as long as it takes for the server to respond
1. Instead, a nice blue alert should display explaining that there are no encounters
